### PR TITLE
Add ZBX_SERVER_HOST enviroment variable for passive proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,4 +32,5 @@ services:
     environment:
      - "ZBX_START_POLLERS=100"
      - "ZBX_TIMEOUT=30"
+     - "ZBX_HOSTNAME=0.0.0.0/0"
     cpu_quota: 50000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,5 +32,5 @@ services:
     environment:
      - "ZBX_START_POLLERS=100"
      - "ZBX_TIMEOUT=30"
-     - "ZBX_HOSTNAME=0.0.0.0/0"
+     - "ZBX_SERVER_HOST=0.0.0.0/0"
     cpu_quota: 50000


### PR DESCRIPTION
https://www.zabbix.com/documentation/4.0/manual/appendix/config/zabbix_proxy
https://hub.docker.com/r/zabbix/zabbix-proxy-sqlite3/

If ProxyMode is set to active mode:
- IP address or DNS name of Zabbix server to get configuration data from and send data to.

If ProxyMode is set to passive mode:
- List of comma delimited IP addresses, optionally in CIDR notation, or DNS names of Zabbix server. Incoming connections will be accepted only from the addresses listed here. If IPv6 support is enabled then '127.0.0.1', '::127.0.0.1', '::ffff:127.0.0.1' are treated equally and '::/0' will allow any IPv4 or IPv6 address. '0.0.0.0/0' can be used to allow any IPv4 address. Example: Server=127.0.0.1,192.168.1.0/24,::1,2001:db8::/32,zabbix.example.com